### PR TITLE
fixes: Pro config options not parsed properly

### DIFF
--- a/src/JuiceboxFormatter.php
+++ b/src/JuiceboxFormatter.php
@@ -452,7 +452,7 @@ class JuiceboxFormatter implements JuiceboxFormatterInterface, TrustedCallbackIn
           // values.
           $matches = [];
           preg_match('/^([A-Za-z0-9]+?)="([^"]+?)"$/u', $option, $matches);
-          list($name, $value) = $matches;
+          list(, $name, $value) = $matches;
           $gallery->addOption(mb_strtolower($name), Html::escape($value));
         }
       }


### PR DESCRIPTION
The regression was introduced with previous changes (commit #b72b6e9) concerning coding standards.

https://git.drupalcode.org/project/juicebox/-/blob/8.x-2.x/src/JuiceboxFormatter.php line 395

list($full_match, $name, $value) = $matches;
was changed to
list($name, $value) = $matches;
to prevent 'Unused variable $full_match '...
This change breaks parsing of manual Pro config options due to missing param in list command.
https://www.php.net/manual/en/function.list.php

We should definitely review all commits concerning list command to fix other potential regressions we didn't noticed until now. 
